### PR TITLE
Python 2.4 compat; graceful failure if probe hasn't run

### DIFF
--- a/Bundler/accounts.genshi
+++ b/Bundler/accounts.genshi
@@ -66,7 +66,10 @@
   def parse_accounts(elements):
     for el in elements:
       if el.tag == 'UnixUser':
-        base_dir = '/' if el.get('name') == 'root' else '/home/'
+        if el.get('name') == 'root':
+          base_dir = '/'
+        else:
+          base_dir = '/home/'
         user = {
           'uid': el.get('uid'),
           'gid': el.get('gid', el.get('uid')),

--- a/Bundler/accounts.genshi
+++ b/Bundler/accounts.genshi
@@ -91,21 +91,22 @@
       elif matches_me(el):
         parse_accounts(el)
 
-  for line in metadata.Probes['accounts'].splitlines():
-    fields = line.split(':')
-    if fields[0] == 'U':
-      existing['user'][fields[1]] = {
-        'uid': fields[2],
-        'group': fields[3],
-        'gecos': fields[4],
-        'home': fields[5],
-        'shell': fields[6],
-        'extra_groups': ','.join(sorted(fields[7].split()))
-      }
-    elif fields[0] == 'G':
-      existing['group'][fields[1]] = {
-        'gid': fields[2]
-      }
+  if 'accounts' in metadata.Probes:
+    for line in metadata.Probes['accounts'].splitlines():
+      fields = line.split(':')
+      if fields[0] == 'U':
+        existing['user'][fields[1]] = {
+          'uid': fields[2],
+          'group': fields[3],
+          'gecos': fields[4],
+          'home': fields[5],
+          'shell': fields[6],
+          'extra_groups': ','.join(sorted(fields[7].split()))
+        }
+      elif fields[0] == 'G':
+        existing['group'][fields[1]] = {
+          'gid': fields[2]
+        }
 
   try:
     accounts_xml = metadata.Properties['accounts.xml'].xdata


### PR DESCRIPTION
The ternary operator was added in Python 2.5, so the template doesn't work on RHEL 5.  This fixes that.

Additionally, if the probe hasn't run yet, the template crashes and burns.  That includes running bcfg2-lint or bcfg2-test without the accounts probe added to probed.xml.  This also fixes that and fails gracefully.
